### PR TITLE
Add UUID field to Launch model

### DIFF
--- a/ReportPortal.Client/Models/Launch.cs
+++ b/ReportPortal.Client/Models/Launch.cs
@@ -11,6 +11,9 @@ namespace ReportPortal.Client.Models
         [DataMember(Name = "id")]
         public string Id { get; set; }
 
+        [DataMember(Name = "uuid")]
+        public string Uuid { get; set; }
+
         [DataMember(Name = "name")]
         public string Name { get; set; }
 


### PR DESCRIPTION
This PR is to prevent the issue while starting a test suite or item but not having the launch uuid with the .NET Client. So just adding the property Uuid to return this field.

Issues is similar to the following:
https://github.com/reportportal/reportportal/issues/678