### PR TITLE
Make stacktrace of rp service exception shorter

### DIFF
--- a/src/ReportPortal.Client/Resources/ServiceBaseResource.cs
+++ b/src/ReportPortal.Client/Resources/ServiceBaseResource.cs
@@ -19,26 +19,26 @@ namespace ReportPortal.Client.Resources
 
         protected string ProjectName { get; }
 
-        protected async Task<TResponse> GetAsJsonAsync<TResponse>(string uri, CancellationToken cancellationToken)
+        protected Task<TResponse> GetAsJsonAsync<TResponse>(string uri, CancellationToken cancellationToken)
         {
-            return await SendAsJsonAsync<TResponse, object>(HttpMethod.Get, uri, null, cancellationToken).ConfigureAwait(false);
+            return SendAsJsonAsync<TResponse, object>(HttpMethod.Get, uri, null, cancellationToken);
         }
 
-        protected async Task<TResponse> PostAsJsonAsync<TResponse, TRequest>(
+        protected Task<TResponse> PostAsJsonAsync<TResponse, TRequest>(
             string uri, TRequest request, CancellationToken cancellationToken)
         {
-            return await SendAsJsonAsync<TResponse, TRequest>(HttpMethod.Post, uri, request, cancellationToken).ConfigureAwait(false);
+            return SendAsJsonAsync<TResponse, TRequest>(HttpMethod.Post, uri, request, cancellationToken);
         }
 
-        protected async Task<TResponse> PutAsJsonAsync<TResponse, TRequest>(
+        protected Task<TResponse> PutAsJsonAsync<TResponse, TRequest>(
             string uri, TRequest request, CancellationToken cancellationToken)
         {
-            return await SendAsJsonAsync<TResponse, TRequest>(HttpMethod.Put, uri, request, cancellationToken).ConfigureAwait(false);
+            return SendAsJsonAsync<TResponse, TRequest>(HttpMethod.Put, uri, request, cancellationToken);
         }
 
-        protected async Task<TResponse> DeleteAsJsonAsync<TResponse>(string uri, CancellationToken cancellationToken)
+        protected Task<TResponse> DeleteAsJsonAsync<TResponse>(string uri, CancellationToken cancellationToken)
         {
-            return await SendAsJsonAsync<TResponse, object>(HttpMethod.Delete, uri, null, cancellationToken).ConfigureAwait(false);
+            return SendAsJsonAsync<TResponse, object>(HttpMethod.Delete, uri, null, cancellationToken);
         }
 
         private async Task<TResponse> SendAsJsonAsync<TResponse, TRequest>(

--- a/src/ReportPortal.Client/Resources/ServiceLaunchResource.cs
+++ b/src/ReportPortal.Client/Resources/ServiceLaunchResource.cs
@@ -14,9 +14,9 @@ namespace ReportPortal.Client.Resources
         {
         }
 
-        public async Task<LaunchResponse> GetAsync(string uuid)
+        public Task<LaunchResponse> GetAsync(string uuid)
         {
-            return await GetAsync(uuid, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(uuid, CancellationToken.None);
         }
 
         public async Task<LaunchResponse> GetAsync(string uuid, CancellationToken cancellationToken)
@@ -24,9 +24,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<LaunchResponse>($"{ProjectName}/launch/uuid/{uuid}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<LaunchResponse> GetAsync(long id)
+        public Task<LaunchResponse> GetAsync(long id)
         {
-            return await GetAsync(id, CancellationToken.None);
+            return GetAsync(id, CancellationToken.None);
         }
 
         public async Task<LaunchResponse> GetAsync(long id, CancellationToken cancellationToken)
@@ -34,9 +34,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<LaunchResponse>($"{ProjectName}/launch/{id}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<LaunchCreatedResponse> StartAsync(StartLaunchRequest request)
+        public Task<LaunchCreatedResponse> StartAsync(StartLaunchRequest request)
         {
-            return await StartAsync(request, CancellationToken.None).ConfigureAwait(false);
+            return StartAsync(request, CancellationToken.None);
         }
 
         public async Task<LaunchCreatedResponse> StartAsync(StartLaunchRequest request, CancellationToken cancellationToken)
@@ -45,9 +45,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/launch", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<LaunchFinishedResponse> FinishAsync(string uuid, FinishLaunchRequest request)
+        public Task<LaunchFinishedResponse> FinishAsync(string uuid, FinishLaunchRequest request)
         {
-            return await FinishAsync(uuid, request, CancellationToken.None).ConfigureAwait(false);
+            return FinishAsync(uuid, request, CancellationToken.None);
         }
 
         public async Task<LaunchFinishedResponse> FinishAsync(string uuid, FinishLaunchRequest request, CancellationToken cancellationToken)
@@ -56,9 +56,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/launch/{uuid}/finish", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<LaunchFinishedResponse> StopAsync(long id, FinishLaunchRequest request)
+        public Task<LaunchFinishedResponse> StopAsync(long id, FinishLaunchRequest request)
         {
-            return await StopAsync(id, request, CancellationToken.None).ConfigureAwait(false);
+            return StopAsync(id, request, CancellationToken.None);
         }
 
         public async Task<LaunchFinishedResponse> StopAsync(long id, FinishLaunchRequest request, CancellationToken cancellationToken)
@@ -67,9 +67,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/launch/{id}/stop", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> DeleteAsync(long id)
+        public Task<MessageResponse> DeleteAsync(long id)
         {
-            return await DeleteAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return DeleteAsync(id, CancellationToken.None);
         }
 
         public async Task<MessageResponse> DeleteAsync(long id, CancellationToken cancellationToken)
@@ -77,9 +77,9 @@ namespace ReportPortal.Client.Resources
             return await DeleteAsJsonAsync<MessageResponse>($"{ProjectName}/launch/{id}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<LaunchResponse> MergeAsync(MergeLaunchesRequest request)
+        public Task<LaunchResponse> MergeAsync(MergeLaunchesRequest request)
         {
-            return await MergeAsync(request, CancellationToken.None).ConfigureAwait(false);
+            return MergeAsync(request, CancellationToken.None);
         }
 
         public async Task<LaunchResponse> MergeAsync(MergeLaunchesRequest request, CancellationToken cancellationToken)
@@ -88,9 +88,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/launch/merge", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> UpdateAsync(long id, UpdateLaunchRequest request)
+        public Task<MessageResponse> UpdateAsync(long id, UpdateLaunchRequest request)
         {
-            return await UpdateAsync(id, request, CancellationToken.None).ConfigureAwait(false);
+            return UpdateAsync(id, request, CancellationToken.None);
         }
 
         public async Task<MessageResponse> UpdateAsync(long id, UpdateLaunchRequest request, CancellationToken cancellationToken)
@@ -99,9 +99,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/launch/{id}/update", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> AnalyzeAsync(AnalyzeLaunchRequest request)
+        public Task<MessageResponse> AnalyzeAsync(AnalyzeLaunchRequest request)
         {
-            return await AnalyzeAsync(request, CancellationToken.None).ConfigureAwait(false);
+            return AnalyzeAsync(request, CancellationToken.None);
         }
 
         public async Task<MessageResponse> AnalyzeAsync(AnalyzeLaunchRequest request, CancellationToken cancellationToken)
@@ -110,14 +110,14 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/launch/analyze", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<Content<LaunchResponse>> GetAsync()
+        public Task<Content<LaunchResponse>> GetAsync()
         {
-            return await GetAsync(filterOption: null, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(filterOption: null, CancellationToken.None);
         }
         
-        public async Task<Content<LaunchResponse>> GetAsync(FilterOption filterOption)
+        public Task<Content<LaunchResponse>> GetAsync(FilterOption filterOption)
         {
-            return await GetAsync(filterOption, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(filterOption, CancellationToken.None);
         }
 
         public async Task<Content<LaunchResponse>> GetAsync(CancellationToken cancellationToken)
@@ -137,14 +137,14 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<Content<LaunchResponse>>(uri, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<Content<LaunchResponse>> GetDebugAsync()
+        public Task<Content<LaunchResponse>> GetDebugAsync()
         {
-            return await GetDebugAsync(filterOption: null, CancellationToken.None).ConfigureAwait(false);
+            return GetDebugAsync(filterOption: null, CancellationToken.None);
         }
 
-        public async Task<Content<LaunchResponse>> GetDebugAsync(FilterOption filterOption)
+        public Task<Content<LaunchResponse>> GetDebugAsync(FilterOption filterOption)
         {
-            return await GetDebugAsync(filterOption, CancellationToken.None).ConfigureAwait(false);
+            return GetDebugAsync(filterOption, CancellationToken.None);
         }
 
         public async Task<Content<LaunchResponse>> GetDebugAsync(CancellationToken cancellationToken)

--- a/src/ReportPortal.Client/Resources/ServiceLogItemResource.cs
+++ b/src/ReportPortal.Client/Resources/ServiceLogItemResource.cs
@@ -19,14 +19,14 @@ namespace ReportPortal.Client.Resources
         {
         }
 
-        public async Task<Content<LogItemResponse>> GetAsync()
+        public Task<Content<LogItemResponse>> GetAsync()
         {
-            return await GetAsync(filterOption: null, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(filterOption: null, CancellationToken.None);
         }
 
-        public async Task<Content<LogItemResponse>> GetAsync(FilterOption filterOption)
+        public Task<Content<LogItemResponse>> GetAsync(FilterOption filterOption)
         {
-            return await GetAsync(filterOption, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(filterOption, CancellationToken.None);
         }
 
         public async Task<Content<LogItemResponse>> GetAsync(CancellationToken cancellationToken)
@@ -46,9 +46,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<Content<LogItemResponse>>(uri, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<LogItemResponse> GetAsync(string uuid)
+        public Task<LogItemResponse> GetAsync(string uuid)
         {
-            return await GetAsync(uuid, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(uuid, CancellationToken.None);
         }
 
         public async Task<LogItemResponse> GetAsync(string uuid, CancellationToken cancellationToken)
@@ -56,9 +56,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<LogItemResponse>($"{ProjectName}/log/uuid/{uuid}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<LogItemResponse> GetAsync(long id)
+        public Task<LogItemResponse> GetAsync(long id)
         {
-            return await GetAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(id, CancellationToken.None);
         }
 
         public async Task<LogItemResponse> GetAsync(long id, CancellationToken cancellationToken)
@@ -66,9 +66,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<LogItemResponse>($"{ProjectName}/log/{id}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<byte[]> GetBinaryDataAsync(string id)
+        public Task<byte[]> GetBinaryDataAsync(string id)
         {
-            return await GetBinaryDataAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return GetBinaryDataAsync(id, CancellationToken.None);
         }
 
         public async Task<byte[]> GetBinaryDataAsync(string id, CancellationToken cancellationToken)
@@ -76,9 +76,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsBytesAsync($"data/{ProjectName}/{id}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<LogItemCreatedResponse> CreateAsync(CreateLogItemRequest request)
+        public Task<LogItemCreatedResponse> CreateAsync(CreateLogItemRequest request)
         {
-            return await CreateAsync(request, CancellationToken.None).ConfigureAwait(false);
+            return CreateAsync(request, CancellationToken.None);
         }
 
         public async Task<LogItemCreatedResponse> CreateAsync(CreateLogItemRequest request, CancellationToken cancellationToken)
@@ -96,9 +96,9 @@ namespace ReportPortal.Client.Resources
             }
         }
 
-        public async Task<LogItemsCreatedResponse> CreateAsync(CreateLogItemRequest[] requests)
+        public Task<LogItemsCreatedResponse> CreateAsync(CreateLogItemRequest[] requests)
         {
-            return await CreateAsync(requests, CancellationToken.None).ConfigureAwait(false);
+            return CreateAsync(requests, CancellationToken.None);
         }
 
         public async Task<LogItemsCreatedResponse> CreateAsync(CreateLogItemRequest[] requests, CancellationToken cancellationToken)
@@ -130,9 +130,9 @@ namespace ReportPortal.Client.Resources
             }
         }
 
-        public async Task<MessageResponse> DeleteAsync(long id)
+        public Task<MessageResponse> DeleteAsync(long id)
         {
-            return await DeleteAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return DeleteAsync(id, CancellationToken.None);
         }
 
         public async Task<MessageResponse> DeleteAsync(long id, CancellationToken cancellationToken)

--- a/src/ReportPortal.Client/Resources/ServiceProjectResource.cs
+++ b/src/ReportPortal.Client/Resources/ServiceProjectResource.cs
@@ -13,9 +13,9 @@ namespace ReportPortal.Client.Resources
         {
         }
 
-        public async Task<ProjectResponse> GetAsync()
+        public Task<ProjectResponse> GetAsync()
         {
-            return await GetAsync(CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(CancellationToken.None);
         }
 
         public async Task<ProjectResponse> GetAsync(CancellationToken cancellationToken)
@@ -23,9 +23,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<ProjectResponse>($"project/{ProjectName}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<ProjectResponse> GetAsync(string projectName)
+        public Task<ProjectResponse> GetAsync(string projectName)
         {
-            return await GetAsync(projectName, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(projectName, CancellationToken.None);
         }
 
         public async Task<ProjectResponse> GetAsync(string projectName, CancellationToken cancellationToken)
@@ -33,9 +33,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<ProjectResponse>($"project/{projectName}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> UpdatePreferencesAsync(string projectName, string userName, long filterId)
+        public Task<MessageResponse> UpdatePreferencesAsync(string projectName, string userName, long filterId)
         {
-            return await UpdatePreferencesAsync(projectName, userName, filterId, CancellationToken.None).ConfigureAwait(false);
+            return UpdatePreferencesAsync(projectName, userName, filterId, CancellationToken.None);
         }
 
         public async Task<MessageResponse> UpdatePreferencesAsync(
@@ -47,16 +47,16 @@ namespace ReportPortal.Client.Resources
                 cancellationToken).ConfigureAwait(false);
         }
 
+        public Task<PreferenceResponse> GetAllPreferencesAsync(string projectName, string userName)
+        {
+            return GetAllPreferencesAsync(projectName, userName, CancellationToken.None);
+        }
+
         public async Task<PreferenceResponse> GetAllPreferencesAsync(
             string projectName, string userName, CancellationToken cancellationToken)
         {
             return await GetAsJsonAsync<PreferenceResponse>(
                 $"project/{projectName}/preference/{userName}", cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task<PreferenceResponse> GetAllPreferencesAsync(string projectName, string userName)
-        {
-            return await GetAllPreferencesAsync(projectName, userName, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/src/ReportPortal.Client/Resources/ServiceTestItemResource.cs
+++ b/src/ReportPortal.Client/Resources/ServiceTestItemResource.cs
@@ -15,14 +15,14 @@ namespace ReportPortal.Client.Resources
         {
         }
 
-        public async Task<Content<TestItemResponse>> GetAsync()
+        public Task<Content<TestItemResponse>> GetAsync()
         {
-            return await GetAsync(filterOption: null, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(filterOption: null, CancellationToken.None);
         }
 
-        public async Task<Content<TestItemResponse>> GetAsync(FilterOption filterOption)
+        public Task<Content<TestItemResponse>> GetAsync(FilterOption filterOption)
         {
-            return await GetAsync(filterOption, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(filterOption, CancellationToken.None);
         }
 
         public async Task<Content<TestItemResponse>> GetAsync(CancellationToken cancellationToken)
@@ -41,9 +41,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<Content<TestItemResponse>>(uri, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<TestItemResponse> GetAsync(long id)
+        public Task<TestItemResponse> GetAsync(long id)
         {
-            return await GetAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(id, CancellationToken.None);
         }
 
         public async Task<TestItemResponse> GetAsync(long id, CancellationToken cancellationToken)
@@ -51,9 +51,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<TestItemResponse>($"{ProjectName}/item/{id}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<TestItemResponse> GetAsync(string uuid)
+        public Task<TestItemResponse> GetAsync(string uuid)
         {
-            return await GetAsync(uuid, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(uuid, CancellationToken.None);
         }
 
         public async Task<TestItemResponse> GetAsync(string uuid, CancellationToken cancellationToken)
@@ -61,9 +61,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<TestItemResponse>($"{ProjectName}/item/uuid/{uuid}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<TestItemCreatedResponse> StartAsync(StartTestItemRequest request)
+        public Task<TestItemCreatedResponse> StartAsync(StartTestItemRequest request)
         {
-            return await StartAsync(request, CancellationToken.None).ConfigureAwait(false);
+            return StartAsync(request, CancellationToken.None);
         }
 
         public async Task<TestItemCreatedResponse> StartAsync(StartTestItemRequest request, CancellationToken cancellationToken)
@@ -72,9 +72,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/item", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<TestItemCreatedResponse> StartAsync(string uuid, StartTestItemRequest model)
+        public Task<TestItemCreatedResponse> StartAsync(string uuid, StartTestItemRequest model)
         {
-            return await StartAsync(uuid, model, CancellationToken.None).ConfigureAwait(false);
+            return StartAsync(uuid, model, CancellationToken.None);
         }
 
         public async Task<TestItemCreatedResponse> StartAsync(string uuid, StartTestItemRequest request, CancellationToken cancellationToken)
@@ -83,9 +83,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/item/{uuid}", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> FinishAsync(string uuid, FinishTestItemRequest request)
+        public Task<MessageResponse> FinishAsync(string uuid, FinishTestItemRequest request)
         {
-            return await FinishAsync(uuid, request, CancellationToken.None).ConfigureAwait(false);
+            return FinishAsync(uuid, request, CancellationToken.None);
         }
 
         public async Task<MessageResponse> FinishAsync(string uuid, FinishTestItemRequest request, CancellationToken cancellationToken)
@@ -94,9 +94,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/item/{uuid}", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> UpdateAsync(long id, UpdateTestItemRequest request)
+        public Task<MessageResponse> UpdateAsync(long id, UpdateTestItemRequest request)
         {
-            return await UpdateAsync(id, request, CancellationToken.None).ConfigureAwait(false);
+            return UpdateAsync(id, request, CancellationToken.None);
         }
 
         public async Task<MessageResponse> UpdateAsync(long id, UpdateTestItemRequest request, CancellationToken cancellationToken)
@@ -105,9 +105,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/item/{id}/update", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> DeleteAsync(long id)
+        public Task<MessageResponse> DeleteAsync(long id)
         {
-            return await DeleteAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return DeleteAsync(id, CancellationToken.None);
         }
 
         public async Task<MessageResponse> DeleteAsync(long id, CancellationToken cancellationToken)
@@ -115,9 +115,9 @@ namespace ReportPortal.Client.Resources
             return await DeleteAsJsonAsync<MessageResponse>($"{ProjectName}/item/{id}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<IEnumerable<Issue>> AssignIssuesAsync(AssignTestItemIssuesRequest request)
+        public Task<IEnumerable<Issue>> AssignIssuesAsync(AssignTestItemIssuesRequest request)
         {
-            return await AssignIssuesAsync(request, CancellationToken.None).ConfigureAwait(false);
+            return AssignIssuesAsync(request, CancellationToken.None);
         }
 
         public async Task<IEnumerable<Issue>> AssignIssuesAsync(AssignTestItemIssuesRequest request, CancellationToken cancellationToken)
@@ -126,9 +126,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/item", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<Content<TestItemHistoryContainer>> GetHistoryAsync(long id, int depth)
+        public Task<Content<TestItemHistoryContainer>> GetHistoryAsync(long id, int depth)
         {
-            return await GetHistoryAsync(id, depth, CancellationToken.None).ConfigureAwait(false);
+            return GetHistoryAsync(id, depth, CancellationToken.None);
         }
 
         public async Task<Content<TestItemHistoryContainer>> GetHistoryAsync(long id, int depth, CancellationToken cancellationToken)

--- a/src/ReportPortal.Client/Resources/ServiceUserFilterResource.cs
+++ b/src/ReportPortal.Client/Resources/ServiceUserFilterResource.cs
@@ -14,14 +14,14 @@ namespace ReportPortal.Client.Resources
         {
         }
 
-        public async Task<Content<UserFilterResponse>> GetAsync()
+        public Task<Content<UserFilterResponse>> GetAsync()
         {
-            return await GetAsync(filterOption: null, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(filterOption: null, CancellationToken.None);
         }
 
-        public async Task<Content<UserFilterResponse>> GetAsync(FilterOption filterOption)
+        public Task<Content<UserFilterResponse>> GetAsync(FilterOption filterOption)
         {
-            return await GetAsync(filterOption, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(filterOption, CancellationToken.None);
         }
 
         public async Task<Content<UserFilterResponse>> GetAsync(CancellationToken cancellationToken)
@@ -40,9 +40,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<Content<UserFilterResponse>>(uri, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<UserFilterCreatedResponse> CreateAsync(CreateUserFilterRequest request)
+        public Task<UserFilterCreatedResponse> CreateAsync(CreateUserFilterRequest request)
         {
-            return await CreateAsync(request, CancellationToken.None).ConfigureAwait(false);
+            return CreateAsync(request, CancellationToken.None);
         }
 
         public async Task<UserFilterCreatedResponse> CreateAsync(CreateUserFilterRequest request, CancellationToken cancellationToken)
@@ -51,9 +51,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/filter", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> UpdateAsync(long id, UpdateUserFilterRequest request)
+        public Task<MessageResponse> UpdateAsync(long id, UpdateUserFilterRequest request)
         {
-            return await UpdateAsync(id, request, CancellationToken.None).ConfigureAwait(false);
+            return UpdateAsync(id, request, CancellationToken.None);
         }
 
         public async Task<MessageResponse> UpdateAsync(long id, UpdateUserFilterRequest request, CancellationToken cancellationToken)
@@ -62,9 +62,9 @@ namespace ReportPortal.Client.Resources
                 $"{ProjectName}/filter/{id}", request, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<UserFilterResponse> GetAsync(long id)
+        public Task<UserFilterResponse> GetAsync(long id)
         {
-            return await GetAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(id, CancellationToken.None);
         }
 
         public async Task<UserFilterResponse> GetAsync(long id, CancellationToken cancellationToken)
@@ -72,9 +72,9 @@ namespace ReportPortal.Client.Resources
             return await GetAsJsonAsync<UserFilterResponse>($"{ProjectName}/filter/{id}", cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<MessageResponse> DeleteAsync(long id)
+        public Task<MessageResponse> DeleteAsync(long id)
         {
-            return await DeleteAsync(id, CancellationToken.None).ConfigureAwait(false);
+            return DeleteAsync(id, CancellationToken.None);
         }
 
         public async Task<MessageResponse> DeleteAsync(long id, CancellationToken cancellationToken)

--- a/src/ReportPortal.Client/Resources/ServiceUserResource.cs
+++ b/src/ReportPortal.Client/Resources/ServiceUserResource.cs
@@ -12,9 +12,9 @@ namespace ReportPortal.Client.Resources
         {
         }
 
-        public async Task<UserResponse> GetAsync()
+        public Task<UserResponse> GetAsync()
         {
-            return await GetAsync(CancellationToken.None).ConfigureAwait(false);
+            return GetAsync(CancellationToken.None);
         }
 
         public async Task<UserResponse> GetAsync(CancellationToken cancellationToken)

--- a/test/ReportPortal.Client.IntegrationTests/BaseFixture.cs
+++ b/test/ReportPortal.Client.IntegrationTests/BaseFixture.cs
@@ -6,7 +6,7 @@ namespace ReportPortal.Client.IntegrationTests
     {
         protected static readonly string Username = "default";
         protected static readonly string ProjectName = "default_personal";
-        protected readonly Service Service = new Service(new Uri("https://demo.reportportal.io/api/v1"), ProjectName, "aeb09a3b-18ef-4e9e-b647-4645c0e9a74e");
+        protected readonly Service Service = new Service(new Uri("https://demo.reportportal.io/api/v1"), ProjectName, "0e80c23b-9676-4b6b-8255-18ef1dece8b5");
         //protected static readonly string Username = "default";
         //protected static readonly string ProjectName = "default_personal";
         //protected readonly Service Service = new Service(new Uri("http://localhost:8080/api/v1"), ProjectName, "d562c898-7705-49a4-be6d-17a8121715fa");


### PR DESCRIPTION
Fixes #95 

With this PR stacktrace looks like
![image](https://user-images.githubusercontent.com/22616990/197348555-19c71e00-f002-48cf-9b4a-36d3e449706a.png)
