### PR TITLE
Add support to disable ignoring SSL errors

### DIFF
--- a/src/ReportPortal.Client/Service.HttpClientFactory.cs
+++ b/src/ReportPortal.Client/Service.HttpClientFactory.cs
@@ -14,11 +14,13 @@ namespace ReportPortal.Client
         {
             private Uri _baseUri;
             private string _token;
+            private readonly bool _ignoreSslErrors;
 
-            public HttpClientFactory(Uri baseUri, string token)
+            public HttpClientFactory(Uri baseUri, string token, bool ignoreSslErrors)
             {
                 _baseUri = baseUri;
                 _token = token;
+                _ignoreSslErrors = ignoreSslErrors;
             }
 
             public HttpClient Create()
@@ -26,9 +28,15 @@ namespace ReportPortal.Client
                 var httpClientHandler = new HttpClientHandler();
 
 #if !NET462
-                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; };
+                if (_ignoreSslErrors)
+                {
+                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => _ignoreSslErrors;
+                }
 #else
-                ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
+                if (_ignoreSslErrors)
+                {
+                    ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
+                }
                 ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 #endif
 

--- a/src/ReportPortal.Client/Service.cs
+++ b/src/ReportPortal.Client/Service.cs
@@ -19,13 +19,14 @@ namespace ReportPortal.Client
         /// <param name="projectName">A project to manage.</param>
         /// <param name="token">A token for user. Can be UID given from user's profile page.</param>
         /// <param name="httpClientFactory">Factory object to create an instance of <see cref="HttpClient"/>.</param>
-        public Service(Uri uri, string projectName, string token, IHttpClientFactory httpClientFactory = null)
+        /// <param name="ignoreSslErrors">Ignore SSL / TLS errors during https web requests</param>
+        public Service(Uri uri, string projectName, string token, IHttpClientFactory httpClientFactory = null, bool ignoreSslErrors = true)
         {
             ProjectName = projectName;
 
             if (httpClientFactory == null)
             {
-                httpClientFactory = new HttpClientFactory(uri, token);
+                httpClientFactory = new HttpClientFactory(uri, token, ignoreSslErrors);
             }
 
             _httpClient = httpClientFactory.Create();

--- a/test/ReportPortal.Client.IntegrationTests/Negative/Negative.cs
+++ b/test/ReportPortal.Client.IntegrationTests/Negative/Negative.cs
@@ -11,21 +11,21 @@ namespace ReportPortal.Client.IntegrationTests.Negative
         [Fact]
         public async Task IncorrectHost()
         {
-            var service = new Service(new Uri("https://abc.abc/"), "p", "p");
+            var service = new Service(new Uri("https://abc.abc/"), "p", "p", ignoreSslErrors: true);
             await Assert.ThrowsAsync<HttpRequestException>(async () => await service.Launch.GetAsync("123"));
         }
 
         [Fact]
         public async Task IncorrectUrlInCorrectHost()
         {
-            var service = new Service(new Uri("https://rp.epam.com/api/blabla/"), "p", "p");
+            var service = new Service(new Uri("https://rp.epam.com/api/blabla/"), "p", "p", ignoreSslErrors: true);
             await Assert.ThrowsAsync<ServiceException>(async () => await service.Launch.StartAsync(new StartLaunchRequest { Name = "abc" }));
         }
 
         [Fact]
         public async Task IncorrectUuid()
         {
-            var service = new Service(new Uri("https://rp.epam.com/api/v1/"), "default_project", "incorrect_uuid");
+            var service = new Service(new Uri("https://rp.epam.com/api/v1/"), "default_project", "incorrect_uuid", ignoreSslErrors: true);
             await Assert.ThrowsAsync<ServiceException>(async () => await service.Launch.GetAsync());
         }
     }


### PR DESCRIPTION
I found that the code always ignores SSL errors, which isn't great - we'd rather rely on SSL errors to know if there are any MitM attacks.

This PR adds a flag to allow you to choose whether to ignore SSL errors, but defaults it to `true`, so that it's backwards compatible.

Note: I haven't done any specific testing of this PR yet.