### PR TITLE
Promote real release only based on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
       run: dotnet nuget push **/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} -s 'https://nuget.pkg.github.com/reportportal/index.json'
 
   Publish_NuGet:
+    if: startsWith(github.event.ref, 'refs/tags')
     environment: 
       name: NuGet Gallery
       url: https://www.nuget.org/packages/ReportPortal.Client


### PR DESCRIPTION
All pushes to develop automatically are pushed to MyGet and GitHub Packages.
Only if it is tag, then promote pushing to NuGet, with manual approval for sure.